### PR TITLE
Onboarding fixes

### DIFF
--- a/src/account-manager.js
+++ b/src/account-manager.js
@@ -1,22 +1,19 @@
 import { bindActionCreators } from '/libraries/redux/src/index.js';
-import {
-    addAccount,
-    updateLabel as updateAccountLabel,
-    logoutLegacy
-} from '/elements/x-accounts/accounts-redux.js';
 import MixinRedux from '/secure-elements/mixin-redux/mixin-redux.js';
 import AccountsClient from './AccountsClient.standalone.es.js';
 import {
-    WalletType,
+    addAccount,
+    LEGACY,
     login,
     logout,
-    updateLabel as updateWalletLabel,
-    setDefaultWallet,
-    switchWallet,
+    logoutLegacy,
+    populate,
     setFileFlag,
     setWordsFlag,
-    populate,
-    LEGACY
+    switchWallet,
+    updateWalletLabel,
+    updateAccountLabel,
+    WalletType,
 } from './wallet-redux.js';
 import AccountType from './lib/account-type.js';
 
@@ -37,7 +34,7 @@ class AccountManager {
         this.accountsClient = new AccountsClient();
 
         this.accounts = {
-            get: (address) => MixinRedux.store.getState().accounts.entries.get(address),
+            get: (address) => MixinRedux.store.getState().wallets.accounts.get(address),
         };
 
         this._bindStore();
@@ -89,6 +86,7 @@ class AccountManager {
         });
 
         this.actions.updateWalletLabel(result.accountId, result.label);
+
         result.addresses.forEach(address => this.actions.updateAccountLabel(address.address, address.label));
 
         // TODO: Remove unreturned addresses and add new returned addresses
@@ -185,16 +183,15 @@ class AccountManager {
 
         this.actions = bindActionCreators({
             addAccount,
-            updateAccountLabel,
-            setDefaultWallet,
             login,
             logout,
             logoutLegacy,
-            updateWalletLabel,
-            switchWallet,
+            populate,
             setFileFlag,
             setWordsFlag,
-            populate
+            switchWallet,
+            updateAccountLabel,
+            updateWalletLabel,
         }, this.store.dispatch);
     }
 

--- a/src/account-manager.js
+++ b/src/account-manager.js
@@ -13,6 +13,7 @@ import {
     switchWallet,
     updateWalletLabel,
     updateAccountLabel,
+    removeAccount,
     WalletType,
 } from './wallet-redux.js';
 import AccountType from './lib/account-type.js';
@@ -90,6 +91,12 @@ class AccountManager {
         result.addresses.forEach(address => this.actions.updateAccountLabel(address.address, address.label));
 
         // TODO: Remove unreturned addresses and add new returned addresses
+    }
+
+    // for testing
+    async removeAccount(address) {
+        await this._launched;
+        this.actions.removeAccount(address);
     }
 
     async export(accountId, options = {}) {
@@ -192,6 +199,7 @@ class AccountManager {
             switchWallet,
             updateAccountLabel,
             updateWalletLabel,
+            removeAccount,
         }, this.store.dispatch);
     }
 

--- a/src/account-manager.js
+++ b/src/account-manager.js
@@ -1,7 +1,6 @@
 import { bindActionCreators } from '/libraries/redux/src/index.js';
 import {
     addAccount,
-    setAllAccounts,
     updateLabel as updateAccountLabel,
     logoutLegacy
 } from '/elements/x-accounts/accounts-redux.js';
@@ -9,7 +8,6 @@ import MixinRedux from '/secure-elements/mixin-redux/mixin-redux.js';
 import AccountsClient from './AccountsClient.standalone.es.js';
 import {
     WalletType,
-    setAllWallets,
     login,
     logout,
     updateLabel as updateWalletLabel,
@@ -17,6 +15,7 @@ import {
     switchWallet,
     setFileFlag,
     setWordsFlag,
+    populate,
     LEGACY
 } from './wallet-redux.js';
 import AccountType from './lib/account-type.js';
@@ -32,7 +31,6 @@ class AccountManager {
 
     constructor() {
         this._launched = new Promise(res => this._resolveLaunched = res);
-        this.accountsLoaded = new Promise(res => this._resolveAccountsLoaded = res);
     }
 
     async launch() {
@@ -187,9 +185,7 @@ class AccountManager {
 
         this.actions = bindActionCreators({
             addAccount,
-            setAllAccounts,
             updateAccountLabel,
-            setAllWallets,
             setDefaultWallet,
             login,
             logout,
@@ -197,7 +193,8 @@ class AccountManager {
             updateWalletLabel,
             switchWallet,
             setFileFlag,
-            setWordsFlag
+            setWordsFlag,
+            populate
         }, this.store.dispatch);
     }
 
@@ -248,48 +245,7 @@ class AccountManager {
             else throw error;
         }
 
-        const wallets = [];
-        const accounts = [];
-
-        listedWallets.forEach(wallet => {
-
-            if (wallet.type !== WalletType.LEGACY) {
-                wallets.push({
-                    id: wallet.accountId,
-                    label: wallet.label,
-                    type: wallet.type,
-                    fileExported: wallet.fileExported,
-                    wordsExported: wallet.wordsExported,
-                });
-            }
-
-            wallet.addresses.forEach(address => {
-                const entry = {
-                    address: address.address,
-                    label: address.label,
-                    type: AccountType.KEYGUARD_HIGH,
-                    isLegacy: wallet.type === WalletType.LEGACY,
-                    walletId: wallet.accountId,
-                };
-                accounts.push(entry);
-            });
-
-            wallet.contracts.forEach(contract => {
-                const entry = Object.assign({}, contract, {
-                    type: AccountType.VESTING,
-                    stepAmount: contract.stepAmount / 1e5,
-                    totalAmount: contract.totalAmount / 1e5,
-                    isLegacy: wallet.type === WalletType.LEGACY,
-                    walletId: wallet.accountId,
-                });
-                accounts.push(entry);
-            });
-        });
-
-        this.actions.setAllAccounts(accounts);
-        this.actions.setAllWallets(wallets);
-
-        this._resolveAccountsLoaded();
+        this.actions.populate(listedWallets);
     }
 
     _onOnboardingResult(result) {

--- a/src/configure-store.js
+++ b/src/configure-store.js
@@ -2,7 +2,6 @@ import { createStore, applyMiddleware, compose, combineReducers } from '/librari
 import { createLogger } from '/libraries/redux-logger/src/index.js';
 import thunk from '/libraries/redux/src/redux-thunk.js';
 import Config from '/libraries/secure-utils/config/config.js';
-import { reducer as accountReducer } from '/elements/x-accounts/accounts-redux.js';
 import { reducer as transactionReducer } from '/elements/x-transactions/transactions-redux.js';
 import { reducer as networkReducer } from '/elements/x-network-indicator/network-redux.js';
 import { reducer as settingReducer } from './settings/settings-redux.js';
@@ -10,7 +9,6 @@ import { reducer as contactReducer } from '/elements/v-contact-list/contacts-red
 import { reducer as walletReducer } from './wallet-redux.js';
 
 const reducers = {
-    accounts: accountReducer,
     transactions: transactionReducer,
     network: networkReducer,
     settings: settingReducer,

--- a/src/elements/x-loader.js
+++ b/src/elements/x-loader.js
@@ -1,0 +1,41 @@
+import XElement from '/libraries/x-element/x-element.js';
+import accountManager from '../account-manager.js';
+import BrowserDetection from '/libraries/secure-utils/browser-detection/browser-detection.js';
+import MixinRedux from '/secure-elements/mixin-redux/mixin-redux.js';
+import { activeWallet$ } from '../selectors/wallet$.js';
+import XSafe from './x-safe.js';
+
+export default class XLoader extends MixinRedux(XElement) {
+
+    html() {
+        return `
+            <div class="logo">
+                <span class="nq-icon nimiq-logo"></span>
+                <span class="logo-wordmark">Nimiq</span>
+            </div>
+            <div class="loading">
+                <div class="loading-animation"></div>
+                <h2>Hello Nimiq!</h2>
+            </div>
+        `
+    }
+
+    static mapStateToProps(state) {
+        return {
+            activeWallet: activeWallet$(state),
+            walletsLoaded: state.wallets.hasContent,
+        }
+    }
+
+    _onPropertiesChanged(changes) {
+        if (this.properties.walletsLoaded && !this.properties.activeWallet) {
+            accountManager.onboard();
+            return;
+        }
+
+        if (changes.walletsLoaded) {
+            const xSafe = new XSafe(this.$el);
+            this.relayedTxResolvers = xSafe.relayedTxResolvers;
+        }
+    }
+}

--- a/src/elements/x-loader.js
+++ b/src/elements/x-loader.js
@@ -1,6 +1,5 @@
 import XElement from '/libraries/x-element/x-element.js';
 import accountManager from '../account-manager.js';
-import BrowserDetection from '/libraries/secure-utils/browser-detection/browser-detection.js';
 import MixinRedux from '/secure-elements/mixin-redux/mixin-redux.js';
 import { activeWallet$ } from '../selectors/wallet$.js';
 import XSafe from './x-safe.js';

--- a/src/elements/x-loader.js
+++ b/src/elements/x-loader.js
@@ -33,8 +33,11 @@ export default class XLoader extends MixinRedux(XElement) {
         }
 
         if (changes.walletsLoaded) {
-            const xSafe = new XSafe(this.$el);
-            this.relayedTxResolvers = xSafe.relayedTxResolvers;
+            this._xSafe = new XSafe(this.$el);
         }
+    }
+
+    get relayedTxResolvers() {
+        return this._xSafe.relayedTxResolvers;
     }
 }

--- a/src/elements/x-safe.js
+++ b/src/elements/x-safe.js
@@ -172,12 +172,12 @@ export default class XSafe extends MixinRedux(XElement) {
             height: state.network.height,
             hasConsensus: state.network.consensus === 'established',
             activeWallet: activeWallet$(state),
+            walletsLoaded: state.wallets.hasContent,
         }
     }
 
     _onPropertiesChanged(changes) {
-        if (changes.activeWallet === null) {
-            // user logged out of all wallets
+        if (this.properties.walletsLoaded && !this.properties.activeWallet) {
             accountManager.onboard();
             return;
         }

--- a/src/lib/account-type.js
+++ b/src/lib/account-type.js
@@ -2,7 +2,8 @@ const AccountType = {
     KEYGUARD_HIGH: 1,
     KEYGUARD_LOW: 2,
     LEDGER: 3,
-    VESTING: 4
+    VESTING: 4,
+    HTLC: 5,
 };
 
 export default AccountType;

--- a/src/network-client.js
+++ b/src/network-client.js
@@ -1,9 +1,8 @@
 import { NetworkClient as NimiqNetworkClient } from '../node_modules/@nimiq/network-client/dist/NetworkClient.standalone.es.js';
-import Config from '/libraries/secure-utils/config/config.js';
 
 class NetworkClient {
     static getInstance() {
-        this._instance = this._instance || new NetworkClient(Config.src('network'));
+        this._instance = this._instance || new NetworkClient();
         return this._instance;
     }
 

--- a/src/safe.js
+++ b/src/safe.js
@@ -1,4 +1,4 @@
-import XSafe from './elements/x-safe.js';
+import XLoader from './elements/x-loader.js';
 import { bindActionCreators } from '/libraries/redux/src/index.js';
 import MixinRedux from '/secure-elements/mixin-redux/mixin-redux.js';
 import { default as store, Store } from './store.js';
@@ -11,13 +11,18 @@ import networkClient from './network-client.js';
 import MixinSingleton from '/secure-elements/mixin-singleton/mixin-singleton.js';
 import XToast from '/secure-elements/x-toast/x-toast.js';
 import XSafeLock from './elements/x-safe-lock.js';
-import { walletsArray$ } from './selectors/wallet$.js'
 
 class Safe {
     constructor() {
         this._networkLaunched = false;
         this._consensusSyncing = false;
         this._consensusEstablished = false;
+
+        // if browser warning is active, abort
+        const warningTags = ['browser-outdated', 'browser-edge', 'no-local-stoage', 'web-view', 'private-mode'];
+        for (let warningTag of warningTags) {
+            //if (document.body.hasAttribute(warningTag)) return;
+        }
 
         if (localStorage.getItem('lock')) {
             const $safeLock = XSafeLock.createElement();
@@ -26,7 +31,6 @@ class Safe {
         } else {
             this.launchApp();
         }
-
     }
 
     async launchApp() {
@@ -37,20 +41,13 @@ class Safe {
         // Launch account manager
         accountManager.launch();
 
-        /*
-        if (walletsArray$(store.getState()).length === 0) {
-            accountManager.onboard();
-            return;
-        }
-        */
-
         const $appContainer = document.getElementById('app');
 
         // set singleton app container
         MixinSingleton.appContainer = $appContainer;
 
         // start UI
-        this._xApp = new XSafe($appContainer);
+        this._xApp = new XLoader($appContainer);
 
         this.actions = bindActionCreators({
             updateBalances,

--- a/src/safe.js
+++ b/src/safe.js
@@ -19,11 +19,10 @@ class Safe {
         this._consensusEstablished = false;
 
         // if browser warning is active, abort
-        const warningTags = ['browser-outdated', 'browser-edge', 'no-local-stoage', 'web-view', 'private-mode'];
+        const warningTags = ['browser-outdated', 'browser-edge', 'no-local-storage', 'web-view', 'private-mode'];
         for (let warningTag of warningTags) {
             if (document.body.hasAttribute(warningTag)) return;
         }
-
         if (localStorage.getItem('lock')) {
             const $safeLock = XSafeLock.createElement();
             $safeLock.$el.classList.add('nimiq-dark');

--- a/src/safe.js
+++ b/src/safe.js
@@ -36,12 +36,13 @@ class Safe {
 
         // Launch account manager
         accountManager.launch();
-        await accountManager.accountsLoaded;
 
+        /*
         if (walletsArray$(store.getState()).length === 0) {
             accountManager.onboard();
             return;
         }
+        */
 
         const $appContainer = document.getElementById('app');
 

--- a/src/safe.js
+++ b/src/safe.js
@@ -2,7 +2,7 @@ import XLoader from './elements/x-loader.js';
 import { bindActionCreators } from '/libraries/redux/src/index.js';
 import MixinRedux from '/secure-elements/mixin-redux/mixin-redux.js';
 import { default as store, Store } from './store.js';
-import { updateBalances } from '/elements/x-accounts/accounts-redux.js';
+import { updateBalances } from './wallet-redux.js';
 import { addTransactions, markRemoved } from '/elements/x-transactions/transactions-redux.js';
 import { setConsensus, setHeight, setPeerCount, setGlobalHashrate } from '/elements/x-network-indicator/network-redux.js';
 import accountManager from './account-manager.js';
@@ -21,7 +21,7 @@ class Safe {
         // if browser warning is active, abort
         const warningTags = ['browser-outdated', 'browser-edge', 'no-local-stoage', 'web-view', 'private-mode'];
         for (let warningTag of warningTags) {
-            //if (document.body.hasAttribute(warningTag)) return;
+            if (document.body.hasAttribute(warningTag)) return;
         }
 
         if (localStorage.getItem('lock')) {
@@ -141,7 +141,7 @@ class Safe {
 
     _onTransaction(tx) {
         // Check if we know the sender or recipient of the tx
-        const accounts = this.store.getState().accounts.entries;
+        const accounts = this.store.getState().wallets.accounts;
         if (!accounts.has(tx.sender) && !accounts.has(tx.recipient)) {
             console.warn('Not displaying transaction because sender and recipient are unknown:', tx);
             return;

--- a/src/selectors/account$.js
+++ b/src/selectors/account$.js
@@ -2,9 +2,9 @@ import { createSelector } from '/libraries/reselect/src/index.js';
 
 import { LEGACY } from '../wallet-redux.js';
 
-export const accounts$ = state => state.accounts.entries;
+export const accounts$ = state => state.wallets.accounts;
 
-export const hasContent$ = state => state.accounts.hasContent;
+export const hasContent$ = state => state.wallets.hasContent;
 
 const activeWalletId$ = state => state.wallets.activeWalletId;
 

--- a/src/selectors/wallet$.js
+++ b/src/selectors/wallet$.js
@@ -4,13 +4,13 @@ import { legacyAccounts$ } from './account$.js';
 
 const LEGACY_LABEL = 'Single-Address Accounts';
 
-export const wallets$ = state => state.wallets.entries;
+export const wallets$ = state => state.wallets.wallets;
 
 export const hasContent$ = state => state.wallets.hasContent;
 
 export const activeWalletId$ = state => state.wallets.activeWalletId;
 
-const accountsArray$ = state => [...state.accounts.entries.values()];
+const accountsArray$ = state => [...state.wallets.accounts.values()];
 
 export const legacyWallet$ = createSelector(
     legacyAccounts$,

--- a/src/store.js
+++ b/src/store.js
@@ -37,10 +37,8 @@ export class Store {
                     entries: new Map(persistedState.transactions.entries)
                 }),
                 wallets: Object.assign({}, initialWalletState, persistedState.wallets, {
-                    entries: new Map(persistedState.wallets ? persistedState.wallets.entries : [])
-                }),
-                accounts: Object.assign({}, persistedState.accounts, {
-                    entries: new Map(persistedState.accounts.entries)
+                    wallets: new Map(persistedState.wallets ? persistedState.wallets.wallets : []),
+                    accounts: new Map(persistedState.wallets ? persistedState.wallets.accounts: [])
                 }),
                 network: Object.assign({}, initialNetworkState, persistedState.network),
                 settings: Object.assign({}, initialSettingsState, persistedState.settings),
@@ -66,18 +64,15 @@ export class Store {
 
         const wallets =  Object.assign({},
             state.wallets,
-            { entries: [...state.wallets.entries.entries()] }
-        );
-
-        const accounts =  Object.assign({},
-            state.accounts,
-            { entries: [...state.accounts.entries.entries()] }
+            {
+                wallets: [...state.wallets.wallets.entries()],
+                accounts: [...state.wallets.accounts.entries()],
+            }
         );
 
         const persistentState = {
             transactions,
             wallets,
-            accounts,
             network: {
                 oldHeight: state.network.height
             },

--- a/src/wallet-redux.js
+++ b/src/wallet-redux.js
@@ -1,18 +1,19 @@
-// FIXME merge with accounts-redux
-
-import { TypeKeys as AccountTypeKeys } from '/elements/x-accounts/accounts-redux.js';
 import AccountType from './lib/account-type.js';
-import networkClient from '/apps/safe/src/network-client.js';
+import networkClient from './network-client.js';
 
 export const TypeKeys = {
+    ADD_ACCOUNT: 'wallet/add',
     LOGIN: 'wallet/login',
-    SWITCH: 'wallet/switch',
-    SET_ALL: 'wallet/set-all',
-    UPDATE_LABEL: 'wallet/update-label',
     LOGOUT: 'wallet/logout',
-    SET_DEFAULT: 'wallet/set-default',
-    SET_FILE_FLAG: 'wallet/set-file-flag',
+    LOGOUT_LEGACY: 'wallet/logout-legacy',
+    REMOVE_ACCOUNT: 'wallet/remove',
+    POPULATE: 'wallet/populate',
     SET_WORDS_FLAG: 'wallet/set-words-flag',
+    SET_FILE_FLAG: 'wallet/set-file-flag',
+    SWITCH: 'wallet/switch',
+    UPDATE_ACCOUNT_LABEL: 'wallet/update-account-label',
+    UPDATE_BALANCES: 'wallet/update-balances',
+    UPDATE_WALLET_LABEL: 'wallet/update-wallet-label',
 };
 
 export const LEGACY = 'LEGACY';
@@ -24,109 +25,229 @@ export const WalletType = {
 };
 
 export const initialState = {
-    entries: new Map(),
+    wallets: new Map(),
+    accounts: new Map(),
     loading: false,
     hasContent: false,
+    activeWalletId: undefined
 };
 
+/* Helper functions */
+
+function updateMapItem(map, id, update) {
+    return new Map(map).set(
+        id,
+        Object.assign({}, map.get(id), update),
+    )
+}
+
+function sanitizeActiveWalletId(state) {
+    const activeWalletIsEmptyLegacy = state.activeWalletId === LEGACY
+        && ![...state.accounts.values()].some(account => account.isLegacy);
+    const noActiveWallet = state.activeWalletId !== LEGACY && !state.wallets.get(state.activeWalletId);
+
+    if (activeWalletIsEmptyLegacy || noActiveWallet) {
+        // Determine wallet with most accounts and set it as new active wallet
+        const walletIdsWithCount = [...state.accounts.values()]
+            .map(account => account.isLegacy ? LEGACY : account.walletId)
+            .reduce((acc, id) => {
+                acc[id] = acc[id] || 0;
+                acc[id]++;
+                return acc;
+            }, {});
+
+        let highestCount = 0;
+        for (const id of Object.keys(walletIdsWithCount)) {
+            const count = walletIdsWithCount[id];
+            if (count > highestCount) {
+                state.activeWalletId = id;
+                highestCount = count;
+            }
+        }
+    }
+
+    return state;
+}
+
+/* Reducer: State machine where changes happen */
+
 export function reducer(state, action) {
+    // Dynamic helper function
+    function updateState(updatedProperties) {
+        const updatedState = Object.assign({}, state, updatedProperties);
+        return sanitizeActiveWalletId(updatedState);
+    }
+
     if (state === undefined) {
         return initialState;
     }
 
     switch (action.type) {
+        case TypeKeys.ADD_ACCOUNT:
+            const oldEntry = state.accounts.get(action.account.address);
+
+            // Keep balance information we might have
+            // TODO: Check if this is still used actually
+            return updateState({
+                accounts: new Map(state.accounts)
+                    .set(action.account.address, Object.assign({}, action.account, {
+                        balance: oldEntry ? oldEntry.balance : undefined
+                    }))
+            });
+
         case TypeKeys.LOGIN:
-            return Object.assign({}, state, {
-                hasContent: true,
-                entries: new Map(state.entries)
-                    .set(action.wallet.id, Object.assign({}, action.wallet)),
+            return updateState({
+                wallets: new Map(state.wallets).set(action.wallet.id, action.wallet),
                 activeWalletId: action.wallet.id,
             });
 
-        case TypeKeys.SWITCH:
-            return Object.assign({}, state, {
-                activeWalletId: action.walletId,
-            });
-
-        case TypeKeys.SET_ALL:
-            const newEntries = action.wallets.map(x => [
-                x.id,
-                Object.assign({}, state.entries.get(x.id), x)
-            ]);
-
-            const newState = Object.assign({}, state, {
-                hasContent: true,
-                // converts array to map with id as key
-                entries: new Map(newEntries)
-            });
-
-            const activeWalletIsEmptyLegacy = state.activeWalletId === LEGACY && !action.accounts.some(account => account.isLegacy);
-            const noActiveWallet = state.activeWalletId !== LEGACY && !newState.entries.get(state.activeWalletId);
-
-            if (activeWalletIsEmptyLegacy || noActiveWallet) {
-                newState.activeWalletId = action.walletIdWithMostAccounts;
-            }
-
-            return newState;
-
-        case TypeKeys.UPDATE_LABEL: {
-            const entries = new Map(state.entries);
-            entries.set(action.walletId, Object.assign({}, state.entries.get(action.walletId), { label: action.label }));
-
-            return Object.assign({}, state, {
-                entries
-            });
-        }
-
-        case TypeKeys.SET_DEFAULT:
-            return Object.assign({}, state, {
-                activeWalletId: action.id
-            });
-
         case TypeKeys.LOGOUT: {
-            const entries = new Map(state.entries);
-            let activeWalletId = state.activeWalletId;
-            entries.delete(action.walletId);
+            // Remove wallet
+            const wallets = new Map(state.wallets);
+            wallets.delete(action.walletId);
 
-            if (activeWalletId === action.walletId) {
-                // If we logout of the current active key, log into the first available key
-                activeWalletId = entries.size > 0 ? entries.keys().next().value : null;
+            // Remove wallet's accounts
+            const accounts = new Map(state.accounts);
+            for (const account of [...state.accounts.values()]) {
+                if (account.walletId === action.walletId) {
+                    accounts.delete(account);
+                }
             }
 
-            return Object.assign({}, state, {
-                entries,
-                activeWalletId
+            return updateState({
+                wallets,
+                accounts,
             });
         }
 
-        case AccountTypeKeys.LOGOUT_LEGACY: {
-            if (!action.isLastLegacy) return state;
+        case TypeKeys.LOGOUT_LEGACY: {
+            const accounts = new Map(state.accounts);
+            accounts.delete(action.address);
 
-            // Last legacy account was logged out, so choose some other active wallet
-            return Object.assign({}, state, {
-                activeWalletId: state.entries.size > 0 ? state.entries.keys().next().value : null,
+            return updateState({ accounts });
+        }
+
+        case TypeKeys.POPULATE: {
+            const wallets = new Map(state.wallets);
+            const accounts = new Map(state.accounts);
+
+            action.listedWallets.forEach(wallet => {
+                if (wallet.type !== WalletType.LEGACY) {
+                    const entry = {
+                        id: wallet.accountId,
+                        label: wallet.label,
+                        type: wallet.type,
+                        fileExported: wallet.fileExported,
+                        wordsExported: wallet.wordsExported,
+                    };
+
+                    // merge with previous information
+                    wallets.set(
+                        wallet.accountId,
+                        Object.assign({}, wallets.get(wallet.accountId), entry)
+                    );
+                }
+
+                wallet.addresses.forEach(address => {
+                    const entry = {
+                        address: address.address,
+                        label: address.label,
+                        type: AccountType.KEYGUARD_HIGH,
+                        isLegacy: wallet.type === WalletType.LEGACY,
+                        walletId: wallet.accountId,
+                    };
+
+                    // merge with previous information
+                    accounts.set(
+                        address.address,
+                        Object.assign({}, accounts.get(address.address), entry)
+                    );
+                });
+
+                wallet.contracts.forEach(contract => {
+                    const entry = Object.assign({}, contract, {
+                        type: AccountType.VESTING,
+                        stepAmount: contract.stepAmount / 1e5,
+                        totalAmount: contract.totalAmount / 1e5,
+                        isLegacy: wallet.type === WalletType.LEGACY,
+                        walletId: wallet.accountId,
+                    });
+
+                    // merge with previous information
+                    accounts.set(
+                        contract.address,
+                        Object.assign({}, accounts.get(contract.address), entry)
+                    );
+                });
             });
+
+            return updateState({
+                hasContent: true,
+                wallets,
+                accounts,
+            });
+        }
+
+        case TypeKeys.REMOVE_ACCOUNT: {
+            const accounts = new Map(state.accounts);
+            accounts.delete(action.address);
+
+            return updateState({ accounts });
         }
 
         case TypeKeys.SET_FILE_FLAG:
-            return Object.assign({}, state, {
-                entries: new Map(state.entries).set(
-                    action.id,
-                    Object.assign({}, state.entries.get(action.id), { fileExported: action.value }),
-                ),
+            return updateState({
+                wallets: updateMapItem(state.wallets, action.id, { fileExported: action.value }),
             });
 
         case TypeKeys.SET_WORDS_FLAG:
-            return Object.assign({}, state, {
-                entries: new Map(state.entries).set(
-                    action.id,
-                    Object.assign({}, state.entries.get(action.id), { wordsExported: action.value }),
-                ),
+            return updateState({
+                wallets: updateMapItem(state.wallets, action.id, { wordsExported: action.value }),
             });
+
+        case TypeKeys.SWITCH:
+            return updateState({
+                activeWalletId: action.walletId,
+            });
+
+        case TypeKeys.UPDATE_ACCOUNT_LABEL:
+            return updateState({
+                accounts: updateMapItem(state.accounts, action.address, { label: action.label }),
+            });
+
+        case TypeKeys.UPDATE_BALANCES: {
+            const accounts = new Map(state.accounts);
+            for (const [address, balance] of action.balances) {
+                accounts.set(address, Object.assign({}, accounts.get(address), { balance }));
+            }
+
+            return updateState({ accounts });
+        }
+
+        case TypeKeys.UPDATE_WALLET_LABEL:
+            // Only update labels of existing entries (prevents adding legacy accounts)
+            if (!state.wallets.get(action.walletId)) return state;
+
+            return updateState({
+                wallets: updateMapItem(state.wallets, action.walletId, { label: action.label }),
+            });
+
 
         default:
             return state
     }
+}
+
+/* Action creators */
+
+export function addAccount(account) {
+    // subscribe at network
+    networkClient.client.then(client => client.subscribe(account.address));
+
+    return {
+        type: TypeKeys.ADD_ACCOUNT,
+        account
+    };
 }
 
 export function login(wallet) {
@@ -135,53 +256,49 @@ export function login(wallet) {
         wallet
     }
 }
-
-export function switchWallet(walletId) {
-    return {
-        type: TypeKeys.SWITCH,
-        walletId
-    }
-}
-
 export function logout(walletId) {
     return async (dispatch, getState) => {
         const state = getState();
-        const addressesToRemove = [];
-        const addressesToKeep = [];
-
-        let iterator;
-        const accountIterator = state.accounts.entries.values();
-        while ((iterator = accountIterator.next()) && !iterator.done) {
-            const account = iterator.value;
-            if (account.walletId === walletId) {
-                addressesToRemove.push(account.address);
-            } else {
-                addressesToKeep.push(account.address);
-            }
-        }
+        const addressesToKeep = [...state.wallets.accounts.values()].filter(account => account.walletId !== walletId);
 
         dispatch({
             type: TypeKeys.LOGOUT,
             walletId,
-            addressesToRemove,
-            addressesToKeep,
+            addressesToKeep, // for transaction reducer
         });
     }
 }
 
-export function updateLabel(walletId, label) {
-    return {
-        type: TypeKeys.UPDATE_LABEL,
-        walletId,
-        label
+export function logoutLegacy(walletId) {
+    return async (dispatch, getState) => {
+        const state = getState();
+        const account = [...state.wallets.accounts.values()].find(account => account.walletId === walletId);
+        if (!account.isLegacy) throw new Error('Tried to log out an address');
+
+        dispatch({
+            type: TypeKeys.LOGOUT_LEGACY,
+            address: account.address,
+        });
     }
 }
 
-export function setDefaultWallet(id) {
+export function populate(listedWallets) {
+    // subscribe addresses at network
+    const addresses = listedWallets.map(wallet => wallet.addresses.map(account => account.address))
+        .reduce((acc, addresses) => acc.concat(addresses), []);
+    networkClient.client.then(client => client.subscribe(addresses));
+
     return {
-        type: TypeKeys.SET_DEFAULT,
-        id
+        type: TypeKeys.POPULATE,
+        listedWallets,
     };
+}
+
+export function removeAccount(address) {
+    return {
+        type: TypeKeys.REMOVE,
+        address,
+    }
 }
 
 export function setFileFlag(id, value) {
@@ -200,68 +317,32 @@ export function setWordsFlag(id, value) {
     };
 }
 
-export function populate(listedWallets) {
-    return async (dispatch, getState) => {
-        const wallets = [];
-        const accounts = [];
+export function switchWallet(walletId) {
+    return {
+        type: TypeKeys.SWITCH,
+        walletId
+    }
+}
 
-        listedWallets.forEach(wallet => {
+export function updateAccountLabel(address, label) {
+    return {
+        type: TypeKeys.UPDATE_ACCOUNT_LABEL,
+        address,
+        label
+    }
+}
 
-            if (wallet.type !== WalletType.LEGACY) {
-                wallets.push({
-                    id: wallet.accountId,
-                    label: wallet.label,
-                    type: wallet.type,
-                    fileExported: wallet.fileExported,
-                    wordsExported: wallet.wordsExported,
-                });
-            }
+export function updateBalances(balances) {
+    return {
+        type: TypeKeys.UPDATE_BALANCES,
+        balances
+    }
+}
 
-            wallet.addresses.forEach(address => {
-                const entry = {
-                    address: address.address,
-                    label: address.label,
-                    type: AccountType.KEYGUARD_HIGH,
-                    isLegacy: wallet.type === WalletType.LEGACY,
-                    walletId: wallet.accountId,
-                };
-                accounts.push(entry);
-            });
-
-            wallet.contracts.forEach(contract => {
-                const entry = Object.assign({}, contract, {
-                    type: AccountType.VESTING,
-                    stepAmount: contract.stepAmount / 1e5,
-                    totalAmount: contract.totalAmount / 1e5,
-                    isLegacy: wallet.type === WalletType.LEGACY,
-                    walletId: wallet.accountId,
-                });
-                accounts.push(entry);
-            });
-        });
-
-        const walletWithMostAccounts = listedWallets.sort(
-            (a, b) => a.addresses.length > b.addresses.length
-                ? -1
-                : a.addresses.length < b.addresses.length
-                    ? 1
-                    : 0
-        )[0];
-
-        const walletIdWithMostAccounts = walletWithMostAccounts
-            ? walletWithMostAccounts.accountId
-            : accounts.some(account => account.isLegacy)
-                ? LEGACY
-                : undefined;
-
-        // subscribe at network.
-        networkClient.client.then(client => client.subscribe(accounts.map(account => account.address)));
-
-        dispatch({
-            type: TypeKeys.SET_ALL,
-            wallets,
-            accounts,
-            walletIdWithMostAccounts,
-        });
+export function updateWalletLabel(walletId, label) {
+    return {
+        type: TypeKeys.UPDATE_WALLET_LABEL,
+        walletId,
+        label
     }
 }


### PR DESCRIPTION
Solves #77 and https://github.com/nimiq/accounts/issues/203

Goes along with https://github.com/nimiq/elements/pull/25

I refactored accounts-redux into wallet-redux, as they are so tightly coupled it simplified some things a a lot. Not really happy with `wallets` being the name for the now combined store for wallets and accounts. Maybe you have a better suggestion?

I also introduced `x-loader`, which waits until state is ready to be rendered and renders `x-safe` then. Although it might not be necessary anymore with `populate` aka `setAll` not being async anymore, I still think it's nice to have such a mechanism in place.
*Edit*: I just noticed I forgot to style this intermediate screen... it's almost not visible, but still...

Credits to @sisou for the idea to simply check the body attribute for browser warning stuff, to prevent forwarding in that case.