### PR TITLE
Recipient type background check

### DIFF
--- a/src/elements/x-send-transaction/x-send-transaction.js
+++ b/src/elements/x-send-transaction/x-send-transaction.js
@@ -255,6 +255,7 @@ export default class XSendTransaction extends MixinRedux(XElement) {
         if (amount) this.amount = amount;
         if (message) this.message = message;
         this._closeQrScanner(true);
+        this.validateAllFields();
     }
 
     /**


### PR DESCRIPTION
Make the recipient type check a non-required background check and silently ignore failed attempts to check.
The reasoning behind this is that the (invalid) attempt to send funds to a contract is an edge case which is not relevant for most transactions.

Also adds validation for data scanned by the QR scanner.