### PR TITLE
Use nano consensus

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   "devDependencies": {
     "@nimiq/hub-api": "^0.4.2",
     "@nimiq/iqons": "^1.5.1",
-    "@nimiq/network-client": "^0.2.1",
+    "@nimiq/network-client": "^0.2.2",
     "@nimiq/style": "^0.7.3",
     "@nimiq/utils": "^0.3.3",
     "@nimiq/vue-components": "https://github.com/nimiq/vue-components#build/safe",

--- a/src/network-client.js
+++ b/src/network-client.js
@@ -1,4 +1,7 @@
-import { NetworkClient as NimiqNetworkClient } from '../node_modules/@nimiq/network-client/dist/NetworkClient.standalone.es.js';
+import {
+    NetworkClient as NimiqNetworkClient,
+    ConsensusType,
+} from '../node_modules/@nimiq/network-client/dist/NetworkClient.standalone.es.js';
 
 class NetworkClient {
     static getInstance() {
@@ -6,13 +9,8 @@ class NetworkClient {
         return this._instance;
     }
 
-    /**
-     * @param {string} [endpoint]
-     */
-    constructor(endpoint) {
+    constructor() {
         this._isLaunched = false;
-
-        this._endpoint = endpoint;
 
         this.client = new Promise(res => {
             this.clientResolve = res;
@@ -23,7 +21,7 @@ class NetworkClient {
         if (this._isLaunched) return;
         this._isLaunched = true;
 
-        const client = new NimiqNetworkClient(this._endpoint);
+        const client = new NimiqNetworkClient(NimiqNetworkClient.DEFAULT_ENDPOINT, ConsensusType.NANO);
         await client.init();
 
         this.clientResolve(client);

--- a/src/wallet-redux.js
+++ b/src/wallet-redux.js
@@ -287,9 +287,6 @@ export function populate(listedWallets) {
 
         const client = await networkClient.client;
         client.subscribe(addresses);
-
-        const balances = await client.connectPico(addresses, true);
-        dispatch(updateBalances(balances));
     }
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -40,10 +40,10 @@
   dependencies:
     dom-parser "^0.1.5"
 
-"@nimiq/network-client@^0.2.1":
-  version "0.2.1"
-  resolved "https://registry.yarnpkg.com/@nimiq/network-client/-/network-client-0.2.1.tgz#125bfbf83a27c321d5226dae1d07aa6fae01e7ed"
-  integrity sha512-IdmeYibnnY7DQkfVZfGgY2aQ8v4pJ2jllYJqDi/xeTPnR3loKqvJsy4NoPMPNMgaFpy0aU2oVJq0OzlW5Vl/IA==
+"@nimiq/network-client@^0.2.2":
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/@nimiq/network-client/-/network-client-0.2.2.tgz#3fb191e247322dfe365333065c869984b17ec12e"
+  integrity sha512-dfVyBhgR2LeO8qVvcQ+jSqtg8f9NI6u1qns4XlCnE8mNR9cMuP/IW9CeUKoavIgVOnhtSqJahqXj5tqh7RASZA==
   dependencies:
     "@nimiq/core-web" "1.4.3"
     "@nimiq/rpc-events" "^0.0.8"


### PR DESCRIPTION
Use nano consensus instead of fake-pico to fix issues that appeared on fake-pico when staying connected for longer time.
Most sigificantly after some time calls to `_getAccounts` in the nano api do neither return nor throw but keep pending forever.
The issues seem to arise after a warning `PeerChannel: Error while processing 'accounts-proof' message from ...: TypeError: Cannot read property 'accountsHash' of null` is visible in the console.
This does not happen in the testnet though. Thus, the issue might be related to connecting to additional peers after the pico peers (note that in testnet there is only one additional seed node besides the pico peers, while in mainnet there are many more).

However, as the real pico consensus is hopefully coming soon, for now I reverted the safe to using nano consensus.

Requires https://github.com/nimiq/network/pull/10 to be approved and packaged first.

This change is currently already deployed.