### PR TITLE
Persist contacts on-change

### DIFF
--- a/src/elements/v-contact-list/v-contact-list.js
+++ b/src/elements/v-contact-list/v-contact-list.js
@@ -7,6 +7,7 @@ import XPopupMenu from '../x-popup-menu/x-popup-menu.js'
 import XToast from '../x-toast/x-toast.js';
 import BrowserDetection from '../../../node_modules/@nimiq/utils/dist/module/BrowserDetection.js';
 import ReduxProvider from '../../../node_modules/vuejs-redux/bundle.es.js';
+import { Store } from '../../store.js';
 
 export default class VContactList extends MixinRedux(XElement) {
     html() {
@@ -84,9 +85,11 @@ export default class VContactList extends MixinRedux(XElement) {
                 },
                 setContact(label, address) {
                     self.actions.setContact(label, address)
+                    Store.persistContacts()
                 },
                 removeContact(address) {
                     self.actions.removeContact(address)
+                    Store.persistContacts()
                 },
                 notification(msg, type) {
                     XToast[type || 'show'](msg)

--- a/src/elements/x-safe.css
+++ b/src/elements/x-safe.css
@@ -305,9 +305,15 @@ x-card h2 {
     font-weight: bold;
 }
 
+x-card .contact-list .search-field {
+    margin: 0;
+    width: 100%;
+}
+
 x-card .contact-list .list {
-    overflow: auto;
     min-height: 150px;
+    padding-left: 0;
+    padding-right: 0;
 }
 
 footer {

--- a/src/settings/x-settings.js
+++ b/src/settings/x-settings.js
@@ -49,11 +49,9 @@ export default class XSettings extends MixinModal(MixinRedux(XElement)) {
     }
 
     _onClickRemovePersistence() {
-        Store.persist(); // Persist potential changes in contacts
-
         // Remove regular persistence
-        localStorage.removeItem('persistedState');
         // Contacts are not removed on purpose
+        localStorage.removeItem('persistedState');
 
         window.skipPersistingState = true;
         location.reload();

--- a/src/store.js
+++ b/src/store.js
@@ -82,12 +82,19 @@ export class Store {
             },
             settings: state.settings,
         };
-        const persistentContacts = state.contacts;
 
         const stringifiedState = JSON.stringify(persistentState);
-        const stringifiedContacts = JSON.stringify(persistentContacts);
-
         localStorage.setItem('persistedState', stringifiedState);
+
+        this.persistContacts();
+    }
+
+    static persistContacts() {
+        const state = Store.instance.getState();
+
+        const persistentContacts = state.contacts;
+
+        const stringifiedContacts = JSON.stringify(persistentContacts);
         localStorage.setItem('persistedContacts', stringifiedContacts);
     }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -77,7 +77,7 @@
 
 "@nimiq/vue-components@https://github.com/nimiq/vue-components#build/safe":
   version "0.1.0"
-  resolved "https://github.com/nimiq/vue-components#997e460b37644625c5f9a01186ebbb9a0a9df1b3"
+  resolved "https://github.com/nimiq/vue-components#77dd6c63dfc5ac9560edc5764fd71a9d5afa996c"
   dependencies:
     "@nimiq/style" "^0.7.3"
     qr-code "github:nimiq/qr-encoder"


### PR DESCRIPTION
This PR changes the storage behavior for contacts to a save-to-disk on-change, not only on window unload.

Depending which is merged first, either this PR or <sebastian/send-tx> need to add a 
```js
    Store.persistContacts()
```
call in the new VSendTransaction's `addContact` handler.